### PR TITLE
Update Apache commons-compress dependency & bump version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,10 +6,10 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.openrefine.dependencies</groupId>
   <artifactId>vicino</artifactId>
-  <version>1.2</version>
+  <version>1.2.1</version>
   <name>SIMILE Vicino</name>
   <url>https://github.com/OpenRefine/simile-vicino</url>
-  <description>Vicino is near-neightbor search tool. The idea is be able to query data by distance search, with pluggable distance functions.</description>
+  <description>Vicino is near-neighbor search tool. The idea is be able to query data by distance search, with pluggable distance functions.</description>
   <licenses>
     <license>
       <name>3-Clause BSD License</name>
@@ -49,9 +49,9 @@
       <version>1.2</version>
     </dependency>
     <dependency>
-      <groupId>commons-compress</groupId>
+      <groupId>org.apache.commons</groupId>
       <artifactId>commons-compress</artifactId>
-      <version>20050911</version>
+      <version>1.26.0</version>
     </dependency>
   </dependencies>
   <build>
@@ -59,7 +59,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-source-plugin</artifactId>
-        <version>3.2.1</version>
+        <version>3.3.0</version>
         <executions>
           <execution>
             <id>attach-sources</id>
@@ -72,7 +72,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>3.2.0</version>
+        <version>3.6.3</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>


### PR DESCRIPTION
Fixes https://github.com/OpenRefine/OpenRefine/issues/4228 

When I built the POM in 2020, I missed that there was a later version of Apache `commons-compress` available with a different group ID, so we're using an 18 year old version. This PR brings us current and bumps the patch level of our version.

Also minor updates to the Maven version dependencies.

No functional changes.